### PR TITLE
Update rule to hide native ul bullets

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -222,7 +222,7 @@ pre code, .cm-s-obsidian pre.HyperMD-codeblock {
 .cm-s-obsidian span.cm-formatting-list-ul {
   font-weight: bold;
 }
-ul { list-style: none; }
+ul { list-style: none !important; }
 
 li > p {
   display: inline-block;


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/5121426/97499825-7a0d9080-1966-11eb-8a41-40dff5efbf7a.png)
After:
![after](https://user-images.githubusercontent.com/5121426/97499831-7bd75400-1966-11eb-8b50-885408eb4792.png)

---

The issue is caused by these built-in rules in Obsidian v0.9.6:
```css
ul ul,
ol ul {
  list-style-type: disc;
}
ol ol ul,
ol ul ul,
ul ol ul,
ul ul ul {
  list-style-type: disc;
}
```