### PR TITLE
Update obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -222,7 +222,7 @@ pre code, .cm-s-obsidian pre.HyperMD-codeblock {
 .cm-s-obsidian span.cm-formatting-list-ul {
   font-weight: bold;
 }
-ul { list-style: none; }
+ul { list-style: none !important; }
 
 li > p {
   display: inline-block;


### PR DESCRIPTION
Fixing 2nd and 3rd level default markers displayed all the time.
App-level CSS has a more specific declaration for nested ul's, so either !important or explicit declaration is needed.